### PR TITLE
Don't report to Sentry when service already exists

### DIFF
--- a/pkg/k8/endpoints.go
+++ b/pkg/k8/endpoints.go
@@ -90,7 +90,10 @@ func (e *EndpointsWriter) create(endpoints *v1.Endpoints) {
 		if err != nil {
 			// If the resource already exists, we should not attempt backoff behavior
 			if errors.IsAlreadyExists(err) {
-				return backoff.Permanent(err)
+				logger.Info("Endpoints already exists, skipping create",
+					zap.String("name", endpoints.Name),
+					zap.String("namespace", endpoints.ObjectMeta.Namespace))
+				return nil
 			}
 			return err
 		}

--- a/pkg/k8/service.go
+++ b/pkg/k8/service.go
@@ -86,7 +86,10 @@ func (s *ServiceWriter) create(svc *v1.Service) {
 		if err != nil {
 			// If the resource already exists, we don't want backoff behavior
 			if errors.IsAlreadyExists(err) {
-				return backoff.Permanent(err)
+				logger.Info("Service already exists, skipping create",
+					zap.String("name", svc.Name),
+					zap.String("namespace", svc.ObjectMeta.Namespace))
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
https://sentry.io/fair/k8-cross-cluster-controller/issues/530566451/?query=is:unresolved

Don't ship errors about service that already exists to Sentry, just log